### PR TITLE
feat: create your own session id

### DIFF
--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log"
 	"net"
+	"crypto/rand"
+	"encoding/hex"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,6 +18,16 @@ import (
 )
 
 var totalSessions int64
+
+// generateShortID generates a short random hex string.
+func generateShortID(length int) string {
+	bytes := make([]byte, length/2)
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to a timestamp-based string if crypto/rand fails, though unlikely.
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:length]
+	}
+	return hex.EncodeToString(bytes)
+}
 
 // Session represents a chat session with two connected clients.
 type Session struct {
@@ -101,35 +113,57 @@ func (s *RelayServer) handleConnection(conn net.Conn) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	sessionID := clientMsg.SessionID
-	session, exists := s.sessions[sessionID]
+	requestedSessionID := clientMsg.SessionID
+	finalSessionID := requestedSessionID
+	var session *Session
+	var exists bool
 
 	switch clientMsg.Command {
 	case "CREATE":
-		if exists {
-			log.Println("Attempted to create a session that already exists.")
-			conn.Write([]byte("Error: Session already exists\n"))
-			conn.Close()
-			return
+		if requestedSessionID != "" {
+			// User provided a session ID
+			session, exists = s.sessions[requestedSessionID]
+			if exists {
+				// Collision: prepend a short unique ID
+				log.Printf("Session ID '%s' already exists. Generating a new one.", requestedSessionID)
+				prefix := generateShortID(6) // Generate a 6-character hex prefix (3 bytes)
+				finalSessionID = prefix + "-" + requestedSessionID
+				// Check again for the highly unlikely case of collision with the new ID
+				_, exists = s.sessions[finalSessionID]
+				for exists { // Keep generating until unique
+					prefix = generateShortID(6)
+					finalSessionID = prefix + "-" + requestedSessionID
+					_, exists = s.sessions[finalSessionID]
+				}
+				log.Printf("Using modified session ID: '%s'", finalSessionID)
+			} else {
+				// User-provided ID is unique
+				finalSessionID = requestedSessionID
+			}
+		} else {
+			// User did not provide a session ID, generate a new UUID
+			finalSessionID = uuid.New().String()
 		}
-		sessionID = uuid.New().String()
-		session = &Session{ID: sessionID}
+
+		session = &Session{ID: finalSessionID}
 		session.Clients[0] = conn
-		s.sessions[sessionID] = session
+		s.sessions[finalSessionID] = session
 		atomic.AddInt64(&totalSessions, 1)
-		log.Printf("New session created. Total active sessions: %d", len(s.sessions))
-		conn.Write([]byte(fmt.Sprintf("Session created: %s\n", sessionID)))
+		log.Printf("New session created with ID '%s'. Total active sessions: %d", finalSessionID, len(s.sessions))
+		conn.Write([]byte(fmt.Sprintf("Session created: %s\n", finalSessionID)))
 
 	case "JOIN":
+		session, exists = s.sessions[requestedSessionID]
 		if !exists || session.Clients[1] != nil {
-			log.Println("Attempted to join a session that does not exist or is full.")
+			log.Printf("Attempted to join session '%s' which does not exist or is full.", requestedSessionID)
 			conn.Write([]byte("Error: Session not found or full\n"))
 			conn.Close()
 			return
 		}
 		session.Clients[1] = conn
-		log.Printf("Client joined session. Total active sessions: %d", len(s.sessions))
-		conn.Write([]byte(fmt.Sprintf("Joined session: %s\n", sessionID)))
+		finalSessionID = requestedSessionID // For logging and consistency
+		log.Printf("Client joined session '%s'. Total active sessions: %d", finalSessionID, len(s.sessions))
+		conn.Write([]byte(fmt.Sprintf("Joined session: %s\n", finalSessionID)))
 
 		// Start relaying data between clients
 		go s.relayData(session.Clients[0], session.Clients[1], sessionID)

--- a/cmd/relay-server/main.go
+++ b/cmd/relay-server/main.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net"
-	"crypto/rand"
-	"encoding/hex"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -166,8 +166,8 @@ func (s *RelayServer) handleConnection(conn net.Conn) {
 		conn.Write([]byte(fmt.Sprintf("Joined session: %s\n", finalSessionID)))
 
 		// Start relaying data between clients
-		go s.relayData(session.Clients[0], session.Clients[1], sessionID)
-		go s.relayData(session.Clients[1], session.Clients[0], sessionID)
+		go s.relayData(session.Clients[0], session.Clients[1], finalSessionID)
+		go s.relayData(session.Clients[1], session.Clients[0], finalSessionID)
 
 	default:
 		log.Println("Received unknown command from a client.")
@@ -206,7 +206,6 @@ func (s *RelayServer) relayData(src, dst net.Conn, sessionID string) {
 		// Copy a chunk of data. io.Copy will use our limitedSrc.
 		// We copy in chunks to allow the deadline to be checked periodically.
 		_, err := io.CopyN(dst, limitedSrc, 4096)
-
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				log.Println("A session timed out due to 5 minutes of inactivity.")


### PR DESCRIPTION
Relay Server Changes:
- When you create a session, if you provide a session ID that already exists, I'll now add a short unique identifier to the beginning of your desired ID.
- If you don't provide a session ID when creating a session, I'll generate a unique one for you, just like before.
- I'll always let you know the final session ID that was used.

Client UI Changes:
- You can now optionally provide a desired session ID when creating a new session.
- I've updated the placeholder text for the session ID input to guide you (e.g., "Desired Session ID (optional)" for creating a session, and "Session ID to Join" for joining one).
- The client UI will correctly display the actual session ID confirmed by the server, including any changes made due to collisions or if I generated it for you.

Issue https://github.com/bjarneo/hemmelig/issues/1